### PR TITLE
商品編集機能の編集

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,27 @@ class ItemsController < ApplicationController
     @items = Item.find(params[:id])
   end
 
+
+def edit
+  @items = Item.find(params[:id])
+  if current_user != @items.user
+    redirect_to root_path 
+  end
+  
+end
+
+def update
+  @items = Item.find(params[:id])
+  if @items.update(item_params)
+    render :show
+  else
+    render :edit
+  end
+
+end
+
+
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
+  before_action :set_item, only: [:show, :edit, :update]
+  before_action :user_item, only: [:edit, :update]
+
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -18,27 +21,20 @@ class ItemsController < ApplicationController
     end
   end
 
-  def show
-    @items = Item.find(params[:id])
+  def show 
   end
 
 
-def edit
-  @items = Item.find(params[:id])
-  if current_user != @items.user
-    redirect_to root_path 
-  end
-  
+def edit   
 end
 
+
 def update
-  @items = Item.find(params[:id])
   if @items.update(item_params)
     render :show
   else
     render :edit
   end
-
 end
 
 
@@ -49,4 +45,15 @@ end
     params.require(:item).permit(:products_name, :price, :category_id, :products_states_id, :shipping_id, :admins_information_id,
                                  :arrival_date_id, :comments, :image).merge(user_id: current_user.id)
   end
+
+
+  def set_item
+    @items = Item.find(params[:id])
+  end
+
+  def user_item
+    if current_user != @items.user
+      redirect_to root_path 
+  end
+ end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,6 +12,7 @@ class Item < ApplicationRecord
   with_options presence: true do
     validates :products_name
     validates :comments
+    validates :image
     validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
   end
   validates :category_id, :products_states_id, :shipping_id, :admins_information_id, :arrival_date_id,

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -139,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,10 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model:@items, url:item_path, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+      <%= render 'shared/error_messages', model: f.object %> 
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -22,7 +22,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%# <%= f.file_field :image, id:"item-image" %> %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -32,13 +32,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%# <%= f.text_area :products_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %> %>
+      <%= f.text_area :products_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.text_area :comments, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %> %>
+        <%= f.text_area :comments, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -51,12 +51,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:category_id,Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %> %>
+        <%= f.collection_select(:category_id,Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:products_states_id, Products_states.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %> %>
+      <%= f.collection_select(:products_states_id, ProductsStates.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -72,17 +72,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:shipping_id, Shipping.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %> %>
+        <%= f.collection_select(:shipping_id, Shipping.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:admins_information_id, Admins_information.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %> %>
+        <%= f.collection_select(:admins_information_id, AdminsInformation.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%# <%= f.collection_select(:arrival_date_id,Arrival_date.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %> %>
+        <%= f.collection_select(:arrival_date_id,ArrivalDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -100,7 +100,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,7 +9,6 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model:@items, url:item_path, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
       <%= render 'shared/error_messages', model: f.object %> 
 
     <%# 出品画像 %>
@@ -140,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', root_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
     
   <% if user_signed_in? %>
    <% if current_user == @items.user %>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index,:new,:create,:show]
+  resources :items, only: [:index,:new,:create,:show,:edit,:update]
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Item, type: :model do
       it '商品画像を1枚つけないと投稿できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include
+        expect(@item.errors.full_messages).to include("Image can't be blank")
       end
 
       it '商品名がないと投稿できない' do


### PR DESCRIPTION
# WHAT
商品情報編集機能の作成
# WHY
商品情報編集機能実装の為


ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/7c6059e754c9535197cfbbe889d937b8

正しく情報を記入すると、商品の情報を編集できる動画
https://gyazo.com/5c36288fb864c7707c4d97bafd3a590e

入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
https://gyazo.com/2ff38c245254224d667a940e4fb961a6

何も編集せずに更新をしても画像無しの商品にならない動画
https://gyazo.com/0f73a0ae26a084f8f4200ace23e3b43f

ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/ddd8f94fdb981710c1b2e57378be51bc

ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/c5246f44e4638c99db52a851c4883552

商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）
https://gyazo.com/efcbd07ea052c07429b0f4409fa1a23e
